### PR TITLE
removed typo at the interpeter definition for mac

### DIFF
--- a/build_mac.sh
+++ b/build_mac.sh
@@ -1,4 +1,4 @@
-background.png#!/bin/sh
+#!/bin/sh
 
 SRC_FOLDER=`pwd` #assumed to be the current folder, change to compile in another location
 ROOT_FOLDER=`pwd`


### PR DESCRIPTION
There was a typo on the first line, looks like a copy & paste error "background.png"
