### PR TITLE
Avoid overlap between Qt macros and other libs

### DIFF
--- a/cli/routerkeygen-cli.cpp
+++ b/cli/routerkeygen-cli.cpp
@@ -52,7 +52,7 @@ int main(int argc, char * argv[]) {
             try {
                 QVector<QString> r = keygens->at(i)->getResults();
                 if (kg) {
-                    foreach (QString s, r) {
+                    Q_FOREACH (QString s, r) {
                          results.append(keygens->at(i)->kgname + ":" + s);
                      }
                 } else {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ if (Qt5Core_FOUND)
     qt5_wrap_ui(ROUTERKEYGEN_UIS_H ${ROUTERKEYGEN_UIS})
     qt5_add_resources(ROUTERKEYGEN_RCC_SRCS ${ROUTERKEYGEN_RCC})
     add_definitions(-DQT_DISABLE_DEPRECATED_BEFORE=0x000000) #handle deprecated methods
+    add_definitions(-DQT_NO_KEYWORDS)
 else(Qt5Core_FOUND)
     qt4_wrap_ui(ROUTERKEYGEN_UIS_H ${ROUTERKEYGEN_UIS})
     qt4_add_resources(ROUTERKEYGEN_RCC_SRCS ${ROUTERKEYGEN_RCC})

--- a/src/KeygenThread.cpp
+++ b/src/KeygenThread.cpp
@@ -28,7 +28,7 @@ void KeygenThread::run(){
     for ( int i = 0; i < routers->size(); ++i ){
         try{
             QVector<QString> r = routers->at(i)->getResults();
-            foreach (QString s, r) {
+            Q_FOREACH (QString s, r) {
                 results.append(s);
             }
         } catch (int e){

--- a/src/RouterKeygen.cpp
+++ b/src/RouterKeygen.cpp
@@ -389,7 +389,7 @@ void RouterKeygen::scanFinished(int code) {
     enableUI(true);
     switch (code) {
     case QWifiManager::SCAN_OK: {
-            foreach ( QSharedPointer<QScanResult> scanResult, wifiNetworks )
+            Q_FOREACH ( QSharedPointer<QScanResult> scanResult, wifiNetworks )
                 scanResult.clear();
             bool setTabPosition = false;
             if ( wifiNetworks.size() == 0 )

--- a/src/RouterKeygen.h
+++ b/src/RouterKeygen.h
@@ -36,7 +36,7 @@ public:
 protected:
     bool eventFilter(QObject *obj, QEvent *event);
 
-private slots:
+private Q_SLOTS:
     void rightButtonClicked(QObject *obj,const QPoint &p);
     void copyKey();
     void forceRefreshToggle(int);

--- a/src/dialog/UpdateDialog.h
+++ b/src/dialog/UpdateDialog.h
@@ -20,7 +20,7 @@ private:
     Ui::UpdateDialog *ui;
     QString url;
 
-private slots:
+private Q_SLOTS:
     void openWebsite();
     void closeWindow();
 };

--- a/src/dialog/WelcomeDialog.h
+++ b/src/dialog/WelcomeDialog.h
@@ -17,7 +17,7 @@ public:
 private:
     Ui::WelcomeDialog *ui;
 
-private slots:
+private Q_SLOTS:
     void donatePaypal();
     void donateGooglePlay();
     

--- a/src/qcmdlineparser/qcmdlineparser.cpp
+++ b/src/qcmdlineparser/qcmdlineparser.cpp
@@ -42,7 +42,7 @@ void QCmdLineParser::QCmdLineParserPrivate::addOptionalArg(const QCmdLineArgumen
     int idx = m_optionalArgs.count();
     m_optionalArgs.push_back(option);
     m_optionalArgIndex[option.name()] = idx;
-    foreach (const QString& alias, option.aliases())
+    Q_FOREACH (const QString& alias, option.aliases())
         m_optionalArgIndex[alias] = idx;
 }
 
@@ -200,7 +200,7 @@ void QCmdLineParser::disableHelpOption()
     m_d->m_optionalArgIndex.remove("-h");
     m_d->m_optionalArgIndex.remove("--help");
     // re-index everybody
-    foreach (QString str, m_d->m_optionalArgIndex.keys())
+    Q_FOREACH (QString str, m_d->m_optionalArgIndex.keys())
         m_d->m_optionalArgIndex[str]--;
 }
 
@@ -251,7 +251,7 @@ QString QCmdLineParser::QCmdLineParserPrivate::usage(const QString& applicationN
     QTextStream s(&usage);
     s << tr("Usage: %1").arg(applicationName);
 
-    foreach (const QCmdLineArgument arg, m_optionalArgs) {
+    Q_FOREACH (const QCmdLineArgument arg, m_optionalArgs) {
         s << " [" << arg.name();
         if (arg.action() == QCmdLineArgument::StoreValue)
             s << ' ' << arg.valueName();
@@ -299,7 +299,7 @@ QString QCmdLineParser::help() const
             keyName = it->valueName();
 
         QStringList args;
-        foreach(QString name, it->aliases()) {
+        Q_FOREACH(QString name, it->aliases()) {
             args << name;
             if (isStorable) {
                 args.last().append(' ');

--- a/src/wifi/QWifiManager.cpp
+++ b/src/wifi/QWifiManager.cpp
@@ -84,7 +84,7 @@ QVector<QSharedPointer<QScanResult> > & QWifiManager::getScanResults() {
 
 
 void QWifiManager::implScanFinished(int s){
-	emit scanFinished(s);
+	Q_EMIT scanFinished(s);
 }
 
 

--- a/src/wifi/QWifiManager.h
+++ b/src/wifi/QWifiManager.h
@@ -36,9 +36,9 @@ public:
 	const static QString EAP;
 	const static QString OPEN;
 	void setForceScan(bool);
-signals:
+Q_SIGNALS:
 	void scanFinished(int);
-private slots:
+private Q_SLOTS:
 	void implScanFinished(int);
 private:
 	bool forceRefresh;

--- a/src/wifi/QWifiManagerPrivate.cpp
+++ b/src/wifi/QWifiManagerPrivate.cpp
@@ -31,7 +31,7 @@ QVector<QSharedPointer<QScanResult> > & QWifiManagerPrivate::getScanResults() {
 }
 
 void QWifiManagerPrivate::clearPreviousScanResults() {
-    foreach ( QSharedPointer<QScanResult> scanResult, scanResults )
+    Q_FOREACH ( QSharedPointer<QScanResult> scanResult, scanResults )
         scanResult.clear();
 	scanResults.clear();
 }

--- a/src/wifi/QWifiManagerPrivate.h
+++ b/src/wifi/QWifiManagerPrivate.h
@@ -20,7 +20,7 @@ public:
 	virtual void startScan() = 0;
     QVector<QSharedPointer<QScanResult> > & getScanResults();
 
-signals:
+Q_SIGNALS:
 	void scanFinished(int);
 
 protected:

--- a/src/wifi/QWifiManagerPrivateMac.cpp
+++ b/src/wifi/QWifiManagerPrivateMac.cpp
@@ -56,12 +56,12 @@ void QWifiManagerPrivateMac::parseResults() {
     int level;
     clearPreviousScanResults();
     if ( lines.size() <= 1 ){
-        emit scanFinished(QWifiManager::SCAN_OK);
+        Q_EMIT scanFinished(QWifiManager::SCAN_OK);
         return;
     }
     int ssidLimit = lines.at(0).indexOf("BSSID");
     if (ssidLimit == -1 ){
-        emit scanFinished(QWifiManager::SCAN_OK);
+        Q_EMIT scanFinished(QWifiManager::SCAN_OK);
         return;
     }
     for (int i = 1; i < lines.size(); ++i) {
@@ -80,7 +80,7 @@ void QWifiManagerPrivateMac::parseResults() {
             enc = "Open";
         scanResults.append(QSharedPointer<QScanResult>(new QScanResult(ssid, bssid, enc, 0, level)));
     }
-    emit scanFinished(QWifiManager::SCAN_OK);
+    Q_EMIT scanFinished(QWifiManager::SCAN_OK);
 
 }
 

--- a/src/wifi/QWifiManagerPrivateMac.h
+++ b/src/wifi/QWifiManagerPrivateMac.h
@@ -23,7 +23,7 @@ protected:
     void timerEvent(QTimerEvent *event);
 
 
-private slots:
+private Q_SLOTS:
 	void parseResults();
 
 private:

--- a/src/wifi/QWifiManagerPrivateUnix.cpp
+++ b/src/wifi/QWifiManagerPrivateUnix.cpp
@@ -36,29 +36,29 @@ void QWifiManagerPrivateUnix::startScan() {
     QDBusInterface networkManager(NM_DBUS_SERVICE, NM_DBUS_PATH,
                                   NM_DBUS_INTERFACE, QDBusConnection::systemBus());
     if (!networkManager.isValid()) {
-        emit scanFinished(QWifiManager::ERROR_NO_NM);
+        Q_EMIT scanFinished(QWifiManager::ERROR_NO_NM);
         return;
     }
     QDBusReply<QList<QDBusObjectPath> > devices = networkManager.call(
             "GetDevices");
     if (!devices.isValid()) {
-        emit scanFinished(QWifiManager::ERROR);
+        Q_EMIT scanFinished(QWifiManager::ERROR);
         return;
     }
 
     bool foundWifi = false;
-    foreach (const QDBusObjectPath& connection, devices.value()) {
+    Q_FOREACH (const QDBusObjectPath& connection, devices.value()) {
         //qDebug() << connection.path();
         QDBusInterface device(NM_DBUS_SERVICE, connection.path(),
                               NM_DBUS_INTERFACE_DEVICE, QDBusConnection::systemBus());
         if (!device.isValid()) {
-            emit scanFinished(QWifiManager::ERROR);
+            Q_EMIT scanFinished(QWifiManager::ERROR);
             return;
         }
 
         QVariant deviceType = device.property("DeviceType");
         if (!deviceType.isValid()) {
-            emit scanFinished(QWifiManager::ERROR);
+            Q_EMIT scanFinished(QWifiManager::ERROR);
             return;
         }
         //qDebug() << deviceType.toUInt();
@@ -66,7 +66,7 @@ void QWifiManagerPrivateUnix::startScan() {
             foundWifi = true;
             QVariant deviceState = device.property("State");
             if (!deviceState.isValid()) {
-                emit scanFinished(QWifiManager::ERROR);
+                Q_EMIT scanFinished(QWifiManager::ERROR);
                 return;
             }
             if (deviceState.toUInt() <= NM_DEVICE_STATE_UNAVAILABLE)
@@ -75,7 +75,7 @@ void QWifiManagerPrivateUnix::startScan() {
                                                 connection.path(), NM_DBUS_INTERFACE_DEVICE_WIRELESS,
                                                 QDBusConnection::systemBus());
             if (!wirelessDevice->isValid()) {
-                emit scanFinished(QWifiManager::ERROR);
+                Q_EMIT scanFinished(QWifiManager::ERROR);
                 return;
             }
             QDBusConnection::systemBus().connect(NM_DBUS_SERVICE,
@@ -93,11 +93,11 @@ void QWifiManagerPrivateUnix::startScan() {
             QDBusReply<QList<QDBusObjectPath> > accessPoints =
                     wirelessDevice->call("GetAccessPoints");
             if (!accessPoints.isValid()) {
-                emit scanFinished(QWifiManager::ERROR);
+                Q_EMIT scanFinished(QWifiManager::ERROR);
                 return;
             }
             clearPreviousScanResults();
-            foreach (const QDBusObjectPath& connection, accessPoints.value()) {
+            Q_FOREACH (const QDBusObjectPath& connection, accessPoints.value()) {
                 //qDebug() << connection.path();
                 QDBusInterface accessPoint(NM_DBUS_SERVICE, connection.path(),
                                            NM_DBUS_INTERFACE_ACCESS_POINT,
@@ -113,7 +113,7 @@ void QWifiManagerPrivateUnix::startScan() {
                 if (!ssid.isValid() || !mac.isValid() || !frequency.isValid()
                     || !strengh.isValid() || !capabilitiesRSN.isValid()
                     || !capabilitiesWPA.isValid() || !flags.isValid() ) {
-                    emit scanFinished(QWifiManager::ERROR);
+                    Q_EMIT scanFinished(QWifiManager::ERROR);
                     return;
                 }
                 unsigned int capabilities = capabilitiesWPA.toUInt()
@@ -142,14 +142,14 @@ void QWifiManagerPrivateUnix::startScan() {
                             QSharedPointer<QScanResult> ( new QScanResult(ssid.toString(), mac.toString(), enc,
                                         frequency.toInt(), strengh.toInt())));
             }
-            emit scanFinished(QWifiManager::SCAN_OK);
+            Q_EMIT scanFinished(QWifiManager::SCAN_OK);
             return;
         }
     }
     if (foundWifi)
-        emit scanFinished(QWifiManager::ERROR_NO_WIFI_ENABLED);
+        Q_EMIT scanFinished(QWifiManager::ERROR_NO_WIFI_ENABLED);
     else
-        emit scanFinished(QWifiManager::ERROR_NO_WIFI);
+        Q_EMIT scanFinished(QWifiManager::ERROR_NO_WIFI);
 }
 
 void QWifiManagerPrivateUnix::updateAccessPoints() {
@@ -163,26 +163,26 @@ void QWifiManagerPrivateUnix::updateAccessPoints() {
     QDBusInterface device(NM_DBUS_SERVICE, wirelessDevice->path(),
                           NM_DBUS_INTERFACE_DEVICE, QDBusConnection::systemBus());
     if (!device.isValid()) {
-        emit scanFinished(QWifiManager::ERROR);
+        Q_EMIT scanFinished(QWifiManager::ERROR);
         return;
     }
     QVariant deviceState = device.property("State");
     if (!deviceState.isValid()) {
-        emit scanFinished(QWifiManager::ERROR);
+        Q_EMIT scanFinished(QWifiManager::ERROR);
         return;
     }
     if (deviceState.toUInt() <= NM_DEVICE_STATE_UNAVAILABLE) {
-        emit scanFinished(QWifiManager::ERROR_NO_WIFI_ENABLED);
+        Q_EMIT scanFinished(QWifiManager::ERROR_NO_WIFI_ENABLED);
         return; // we are only interested in enabled wifi devices
     }
     QDBusReply<QList<QDBusObjectPath> > accessPoints = wirelessDevice->call(
             "GetAccessPoints");
     if (!accessPoints.isValid()) {
-        emit scanFinished(QWifiManager::ERROR);
+        Q_EMIT scanFinished(QWifiManager::ERROR);
         return;
     }
     clearPreviousScanResults();
-    foreach (const QDBusObjectPath& connection, accessPoints.value()) {
+    Q_FOREACH (const QDBusObjectPath& connection, accessPoints.value()) {
         //qDebug() << connection.path();
         QDBusInterface accessPoint(NM_DBUS_SERVICE, connection.path(),
                                    NM_DBUS_INTERFACE_ACCESS_POINT, QDBusConnection::systemBus());
@@ -197,7 +197,7 @@ void QWifiManagerPrivateUnix::updateAccessPoints() {
         if (!ssid.isValid() || !mac.isValid() || !frequency.isValid()
             || !strengh.isValid() || !capabilitiesRSN.isValid()
             || !capabilitiesWPA.isValid() || !flags.isValid()) {
-            emit scanFinished(QWifiManager::ERROR);
+            Q_EMIT scanFinished(QWifiManager::ERROR);
             return;
         }
         unsigned int capabilities = capabilitiesWPA.toUInt()
@@ -223,6 +223,6 @@ void QWifiManagerPrivateUnix::updateAccessPoints() {
             QSharedPointer<QScanResult> (new QScanResult(ssid.toString(), mac.toString(), enc,
                                 frequency.toInt(), strengh.toInt())));
     }
-    emit scanFinished(QWifiManager::SCAN_OK);
+    Q_EMIT scanFinished(QWifiManager::SCAN_OK);
 }
 

--- a/src/wifi/QWifiManagerPrivateUnix.h
+++ b/src/wifi/QWifiManagerPrivateUnix.h
@@ -21,7 +21,7 @@ public:
 	QWifiManagerPrivateUnix();
 	virtual ~QWifiManagerPrivateUnix();
 	void startScan();
-private slots:
+private Q_SLOTS:
 	void updateAccessPoints();
 
 private:

--- a/src/wifi/QWifiManagerPrivateWin.cpp
+++ b/src/wifi/QWifiManagerPrivateWin.cpp
@@ -69,7 +69,7 @@ void QWifiManagerPrivateWin::parseResults() {
 		}
 
 	}
-	emit scanFinished(QWifiManager::SCAN_OK);
+	Q_EMIT scanFinished(QWifiManager::SCAN_OK);
 }
 
 void QWifiManagerPrivateWin::timerEvent(QTimerEvent *)

--- a/src/wifi/QWifiManagerPrivateWin.h
+++ b/src/wifi/QWifiManagerPrivateWin.h
@@ -23,7 +23,7 @@ protected:
     void timerEvent(QTimerEvent *event);
 
 
-private slots:
+private Q_SLOTS:
 	void parseResults();
 
 private:


### PR DESCRIPTION
Hello,
The build fails on Kali with several issues like
```
In file included from /usr/include/x86_64-linux-gnu/qt5/QtGui/qwindowdefs.h:44,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qwidget.h:44,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qmainwindow.h:44,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/QMainWindow:1,
                 from /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/routerkeygen_autogen/EWIEGA46WW/../../../../src/RouterKeygen.h:3,
                 from /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/routerkeygen_autogen/EWIEGA46WW/moc_RouterKeygen.cpp:10,
                 from /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/routerkeygen_autogen/mocs_compilation.cpp:2:
/usr/include/glib-2.0/gio/gdbusintrospection.h:155:25: error: expected unqualified-id before ‘public’
  155 |   GDBusSignalInfo     **signals;
      |                         ^~~~~~~
```
See https://doc.qt.io/qt-5/signalsandslots.html#using-qt-with-3rd-party-signals-and-slots